### PR TITLE
No more modeState updates based on magic numbers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -251,17 +251,7 @@ export function setTool(state: Tool) {
     treeContext.toolState = state;
     cutTools.style.display = "none";
     atomTools.style.display = "none";
-    treeString.style.display = "none";
-    proofString.style.display = "none";
     selectionDisplay.style.display = "none";
-
-    if (state <= 11) {
-        treeContext.modeState = "Draw";
-        treeString.style.display = "block";
-    } else {
-        treeContext.modeState = "Proof";
-        proofString.style.display = "block";
-    }
 
     switch (treeContext.toolState) {
         case Tool.atomTool:


### PR DESCRIPTION
Updates to mode related elements (like display string and treeContext.modeState) all happen in toggleModes.ts
Task 4 of #241 