### PR TITLE
Dependabot updates for GitHub Actions and groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,15 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
+    groups:
+      all-npm-dependencies:
+        patterns: 
+        - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    all-gh-actions-dependencies:
+        patterns: 
+        - "*"


### PR DESCRIPTION
- Add dependabot updates for GitHub actions 
- Made it so dependabot only opens one PR for all npm updates each week. 