### PR TITLE
388 firefox cannot save or load files fix

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
     "recommendations": [
         "dbaeumer.vscode-eslint",
+        "firefox-devtools.vscode-firefox-debug",
         "streetsidesoftware.code-spell-checker"
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,19 +5,26 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "type": "msedge",
-            "name": "Edge Vite Debug",
-            "request": "launch",
-            "url": "http://localhost:5173/",
-            "webRoot": "${workspaceFolder}/src"
-        },
-        {
             "type": "chrome",
             "request": "launch",
             "name": "Chrome Vite Debug",
             "url": "http://localhost:5173/",
             "webRoot": "${workspaceRoot}/src",
             //"sourceMaps": true,
-        }
+        },
+        {
+            "type": "msedge",
+            "request": "launch",
+            "name": "Edge Vite Debug",
+            "url": "http://localhost:5173/",
+            "webRoot": "${workspaceFolder}/src"
+        },
+        {
+            "type": "firefox",
+            "request": "launch",
+            "name": "Firefox Vite Debug",
+            "url": "http://localhost:5173/",
+            "webRoot": "${workspaceFolder}/src"
+        },
     ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "file-saver": "^2.0.5",
         "fork-awesome": "^1.2.0",
         "theme-change": "^2.5.0"
       },
       "devDependencies": {
+        "@types/file-saver": "^2.0.7",
         "@types/node": "20.12.7",
         "@types/wicg-file-system-access": "^2023.10.5",
         "gts": "^5.3.0",
@@ -866,6 +868,12 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
       "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+      "dev": true
+    },
+    "node_modules/@types/file-saver": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/file-saver/-/file-saver-2.0.7.tgz",
+      "integrity": "sha512-dNKVfHd/jk0SkR/exKGj2ggkB45MAkzvWCaqLUUgkyjITkGNzH8H+yUwr+BLJUBjZOe9w8X3wgmXhZDRg1ED6A==",
       "dev": true
     },
     "node_modules/@types/json-schema": {
@@ -2121,6 +2129,11 @@
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
       }
+    },
+    "node_modules/file-saver": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
+      "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA=="
     },
     "node_modules/fill-range": {
       "version": "7.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
       },
       "devDependencies": {
         "@types/file-saver": "^2.0.7",
-        "@types/node": "20.12.7",
         "@types/node": "20.12.8",
         "@types/wicg-file-system-access": "^2023.10.5",
         "gts": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   "homepage": "https://github.com/RAIRLab/PeirceMyHeart#readme",
   "devDependencies": {
     "@types/file-saver": "^2.0.7",
-    "@types/node": "20.12.7",
     "@types/node": "20.12.8",
     "@types/wicg-file-system-access": "^2023.10.5",
     "gts": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "homepage": "https://github.com/RAIRLab/PeirceMyHeart#readme",
   "devDependencies": {
+    "@types/file-saver": "^2.0.7",
     "@types/node": "20.12.7",
     "@types/wicg-file-system-access": "^2023.10.5",
     "gts": "^5.3.0",
@@ -43,6 +44,7 @@
     "vitest": "^1.5.2"
   },
   "dependencies": {
+    "file-saver": "^2.0.5",
     "fork-awesome": "^1.2.0",
     "theme-change": "^2.5.0"
   }

--- a/src/AEG-IO.ts
+++ b/src/AEG-IO.ts
@@ -4,12 +4,19 @@
  * @author Anusha Tiwari
  */
 
+import {TreeContext} from "./TreeContext";
+import {redrawProof, redrawTree} from "./SharedToolUtils/DrawUtils";
+import {appendStep} from "./ProofHistory/ProofHistory";
+
 import {AEGTree} from "./AEG/AEGTree";
 import {AtomNode} from "./AEG/AtomNode";
 import {CutNode} from "./AEG/CutNode";
 import {Ellipse} from "./AEG/Ellipse";
 import {Point} from "./AEG/Point";
 import {ProofModeMove, ProofModeNode} from "./ProofHistory/ProofModeNode";
+
+//Cross-browser file saving library.
+import FileSaver from "file-saver";
 
 /**
  * Describes The Sheet of Assertion in JSON files.
@@ -157,4 +164,120 @@ function toAtom(atomData: atomObj): AtomNode {
     const origin: Point = new Point(atomData.internalOrigin.x, atomData.internalOrigin.y);
 
     return new AtomNode(identifier, origin, atomData.internalWidth, atomData.internalHeight);
+}
+
+/**
+ * Creates and returns the json string of the given AEG Tree object.
+ *  Uses tab characters as delimiters.
+ * 
+ * @param treeData An AEG Tree object.
+ * @returns json string of treeData.
+ */
+export function aegJsonString(treeData: AEGTree | ProofModeNode[]): string {
+    return JSON.stringify(treeData, null, "\t");
+}
+
+/**
+ * Calls appropriate methods to save the current AEGTree as a file.
+ */
+export async function saveMode(): Promise<void> {
+    let name: string;
+    let data: AEGTree | ProofModeNode[];
+
+    if (TreeContext.modeState === "Draw") {
+        name = TreeContext.tree.toString()
+        data = TreeContext.tree;
+    } else {
+        if (TreeContext.proof.length === 1) {
+            name = "One-Step Proof";
+        } else {
+            name =
+                TreeContext.proof[0].tree.toString() +
+                " PROVES " +
+                TreeContext.getLastProofStep().tree.toString();
+        }
+        data = TreeContext.proof;
+    }
+
+    //Errors caused by file handler or HTML download element should not be displayed.
+    try {
+        //Dialog based download
+        if ("showSaveFilePicker" in window) {
+            const saveHandle = await window.showSaveFilePicker({
+                excludeAcceptAllOption: true,
+                suggestedName: name,
+                startIn: "downloads",
+                types: [{accept: {"text/json": [".json"]}}]
+            });
+            saveFile(saveHandle, data);
+        } else {
+            //Fallback to immediate download if showSaveFilePicker is not supported.
+            let blob = new Blob([aegJsonString(data)], {type: "text/json"});
+            FileSaver(blob, name + ".json");
+        }
+    } catch (error) {
+        //Catch error but do nothing. Discussed in Issue #247.
+    }
+}
+
+function readFile(file: File) {
+    const reader = new FileReader();
+    reader.addEventListener("load", () => {
+        const aegData = reader.result;
+        if (typeof aegData === "string") {
+            const loadData = loadFile(TreeContext.modeState, aegData);
+            if (TreeContext.modeState === "Draw") {
+                //Loads data.
+                TreeContext.tree = loadData as AEGTree;
+                //Redraws tree which is now the parsed loadData.
+                redrawTree(TreeContext.tree);
+            } else if (TreeContext.modeState === "Proof") {
+                //Clears current proof.
+                TreeContext.clearProof();
+                //Loads data for the new proof.
+                TreeContext.proof = loadData as ProofModeNode[];
+                //Removes default start step.
+                document.getElementById("Row: 1")?.remove();
+                //Adds button for each step of the loaded proof to the history bar.
+                for (let i = 0; i < TreeContext.proof.length; i++) {
+                    appendStep(TreeContext.proof[i], i + 1);
+                }
+                TreeContext.currentProofStep = TreeContext.proof[TreeContext.proof.length - 1];
+                redrawProof();
+            }
+        } else {
+            console.log("Loading failed because reading the file was unsuccessful.");
+        }
+    });
+    reader.readAsText(file);
+}
+
+/**
+ * Calls the appropriate methods to load files and convert them to equivalent AEGTrees.
+ */
+export async function loadMode(): Promise<void> {
+
+    try {
+        if("showOpenFilePicker" in window) {
+            const [fileHandle] = await window.showOpenFilePicker({
+                excludeAcceptAllOption: true,
+                multiple: false,
+                startIn: "downloads",
+                types: [{accept: {"text/json": [".json"]}}]
+            });
+            const file = await fileHandle.getFile();
+            readFile(file);
+        } else {
+            const fileInput = document.createElement("input");
+            fileInput.type = "file";
+            fileInput.accept = ".json";
+            fileInput.addEventListener("change", () => {
+                const file = fileInput.files?.item(0);
+                readFile(file!);
+            });
+            fileInput.click();
+        }
+    } catch (error) {
+        //Do nothing.
+    }
 }

--- a/src/AEG-IO.ts
+++ b/src/AEG-IO.ts
@@ -153,7 +153,7 @@ function toCut(cutData: cutObj): CutNode {
 }
 
 /**
- * Parses the incoming AtomObject and returns and equivalent AtomNode.
+ * Parses the incoming AtomObject and returns an equivalent AtomNode.
  *
  * @param atomData Incoming AtomObject.
  * @returns AtomNode equivalent of atomData.
@@ -168,7 +168,7 @@ function toAtom(atomData: atomObj): AtomNode {
 
 /**
  * Creates and returns the json string of the given AEG Tree object.
- *  Uses tab characters as delimiters.
+ * Uses tab characters as delimiters.
  *
  * @param treeData An AEG Tree object.
  * @returns json string of treeData.

--- a/src/AEG-IO.ts
+++ b/src/AEG-IO.ts
@@ -169,7 +169,7 @@ function toAtom(atomData: atomObj): AtomNode {
 /**
  * Creates and returns the json string of the given AEG Tree object.
  *  Uses tab characters as delimiters.
- * 
+ *
  * @param treeData An AEG Tree object.
  * @returns json string of treeData.
  */
@@ -185,7 +185,7 @@ export async function saveMode(): Promise<void> {
     let data: AEGTree | ProofModeNode[];
 
     if (TreeContext.modeState === "Draw") {
-        name = TreeContext.tree.toString()
+        name = TreeContext.tree.toString();
         data = TreeContext.tree;
     } else {
         if (TreeContext.proof.length === 1) {
@@ -207,12 +207,12 @@ export async function saveMode(): Promise<void> {
                 excludeAcceptAllOption: true,
                 suggestedName: name,
                 startIn: "downloads",
-                types: [{accept: {"text/json": [".json"]}}]
+                types: [{accept: {"text/json": [".json"]}}],
             });
             saveFile(saveHandle, data);
         } else {
             //Fallback to immediate download if showSaveFilePicker is not supported.
-            let blob = new Blob([aegJsonString(data)], {type: "text/json"});
+            const blob = new Blob([aegJsonString(data)], {type: "text/json"});
             FileSaver(blob, name + ".json");
         }
     } catch (error) {
@@ -256,14 +256,13 @@ function readFile(file: File) {
  * Calls the appropriate methods to load files and convert them to equivalent AEGTrees.
  */
 export async function loadMode(): Promise<void> {
-
     try {
-        if("showOpenFilePicker" in window) {
+        if ("showOpenFilePicker" in window) {
             const [fileHandle] = await window.showOpenFilePicker({
                 excludeAcceptAllOption: true,
                 multiple: false,
                 startIn: "downloads",
-                types: [{accept: {"text/json": [".json"]}}]
+                types: [{accept: {"text/json": [".json"]}}],
             });
             const file = await fileHandle.getFile();
             readFile(file);

--- a/src/SharedToolUtils/DrawUtils.ts
+++ b/src/SharedToolUtils/DrawUtils.ts
@@ -5,7 +5,7 @@
  * @author Anusha Tiwari
  */
 
-import {aegStringify} from "../index";
+import {aegJsonString} from "../index";
 import {AEGTree} from "../AEG/AEGTree";
 import {AtomNode} from "../AEG/AtomNode";
 import {CutNode} from "../AEG/CutNode";
@@ -174,7 +174,7 @@ export function redrawTree(tree: AEGTree, color?: string): void {
     cutDisplay.innerHTML = tree.toString();
     cleanCanvas();
     redrawCut(tree.sheet, color);
-    window.treeString = aegStringify(tree);
+    window.treeString = aegJsonString(tree);
 }
 
 /**

--- a/src/SharedToolUtils/DrawUtils.ts
+++ b/src/SharedToolUtils/DrawUtils.ts
@@ -5,7 +5,7 @@
  * @author Anusha Tiwari
  */
 
-import {aegJsonString} from "../index";
+import {aegJsonString} from "../AEG-IO";
 import {AEGTree} from "../AEG/AEGTree";
 import {AtomNode} from "../AEG/AtomNode";
 import {CutNode} from "../AEG/CutNode";

--- a/src/index.ts
+++ b/src/index.ts
@@ -194,7 +194,6 @@ function setTool(state: Tool): void {
     }
 }
 
-
 /**
  * Handles CTRL+Z undo operations according to whether the program is in Draw or Proof Mode.
  */

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,10 +8,8 @@
  */
 
 import {AEGTree} from "./AEG/AEGTree";
-import {appendStep} from "./ProofHistory/ProofHistory";
-import {loadFile, saveFile} from "./AEG-IO";
+import {loadMode, saveMode, aegJsonString} from "./AEG-IO";
 import {ProofModeNode} from "./ProofHistory/ProofModeNode";
-import {redrawProof, redrawTree} from "./SharedToolUtils/DrawUtils";
 import {toggleHandler} from "./ToggleModes";
 import {Tool, TreeContext} from "./TreeContext";
 
@@ -40,9 +38,6 @@ import * as InsertionTool from "./ProofTools/InsertionTool";
 import * as ErasureTool from "./ProofTools/ErasureTool";
 import * as ProofResizeTool from "./ProofTools/ProofResizeTool";
 import * as PasteInProof from "./ProofTools/PasteInProof";
-
-//Cross-browser file saving library.
-import FileSaver from "file-saver";
 
 //Setting up canvas...
 const canvas: HTMLCanvasElement = <HTMLCanvasElement>document.getElementById("canvas");
@@ -198,111 +193,7 @@ function setTool(state: Tool): void {
             break;
     }
 }
-/**
- * Creates and returns the json string of the given AEG Tree object.
- *  Uses tab characters as delimiters.
- * 
- * @param treeData An AEG Tree object.
- * @returns json string of treeData.
- */
-export function aegJsonString(treeData: AEGTree | ProofModeNode[]): string {
-    return JSON.stringify(treeData, null, "\t");
-}
 
-/**
- * Calls appropriate methods to save the current AEGTree as a file.
- */
-async function saveMode(): Promise<void> {
-    let name: string;
-    let data: AEGTree | ProofModeNode[];
-
-    if (TreeContext.modeState === "Draw") {
-        name = TreeContext.tree.toString()
-        data = TreeContext.tree;
-    } else {
-        if (TreeContext.proof.length === 1) {
-            name = "One-Step Proof";
-        } else {
-            name =
-                TreeContext.proof[0].tree.toString() +
-                " PROVES " +
-                TreeContext.getLastProofStep().tree.toString();
-        }
-        data = TreeContext.proof;
-    }
-
-    //Errors caused by file handler or HTML download element should not be displayed.
-    try {
-        //Slow Download...
-        if ("showSaveFilePicker" in window) {
-            const saveHandle = await window.showSaveFilePicker({
-                excludeAcceptAllOption: true,
-                suggestedName: name,
-                startIn: "downloads",
-                types: [{accept: {"text/json": [".json"]}}]
-            });
-            saveFile(saveHandle, data);
-        } else {
-            FileSaver(aegJsonString(data), name + ".json");
-        }
-    } catch (error) {
-        //Catch error but do nothing. Discussed in Issue #247.
-    }
-}
-
-/**
- * Calls the appropriate methods to load files and convert them to equivalent AEGTrees.
- */
-async function loadMode(): Promise<void> {
-    try {
-        const [fileHandle] = await window.showOpenFilePicker({
-            excludeAcceptAllOption: true,
-            multiple: false,
-            startIn: "downloads",
-            types: [
-                {
-                    description: "JSON Files",
-                    accept: {
-                        "text/json": [".json"],
-                    },
-                },
-            ],
-        });
-
-        const file = await fileHandle.getFile();
-        const reader = new FileReader();
-        reader.addEventListener("load", () => {
-            const aegData = reader.result;
-            if (typeof aegData === "string") {
-                const loadData = loadFile(TreeContext.modeState, aegData);
-                if (TreeContext.modeState === "Draw") {
-                    //Loads data.
-                    TreeContext.tree = loadData as AEGTree;
-                    //Redraws tree which is now the parsed loadData.
-                    redrawTree(TreeContext.tree);
-                } else if (TreeContext.modeState === "Proof") {
-                    //Clears current proof.
-                    TreeContext.clearProof();
-                    //Loads data for the new proof.
-                    TreeContext.proof = loadData as ProofModeNode[];
-                    //Removes default start step.
-                    document.getElementById("Row: 1")?.remove();
-                    //Adds button for each step of the loaded proof to the history bar.
-                    for (let i = 0; i < TreeContext.proof.length; i++) {
-                        appendStep(TreeContext.proof[i], i + 1);
-                    }
-                    TreeContext.currentProofStep = TreeContext.proof[TreeContext.proof.length - 1];
-                    redrawProof();
-                }
-            } else {
-                console.log("Loading failed because reading the file was unsuccessful.");
-            }
-        });
-        reader.readAsText(file);
-    } catch (error) {
-        //Do nothing.
-    }
-}
 
 /**
  * Handles CTRL+Z undo operations according to whether the program is in Draw or Proof Mode.


### PR DESCRIPTION
* Save now falls back to cross-browser [FileSaver.js library](https://github.com/eligrey/FileSaver.js/)
* Refactored to move `saveMode` and `loadMode` and related utils out of index and into `AEG-IO` where they belong. 
* Filenames for draw mode files are now their string representation. 